### PR TITLE
3rd party tracking update

### DIFF
--- a/easyprivacy/easyprivacy_trackingservers_international.txt
+++ b/easyprivacy/easyprivacy_trackingservers_international.txt
@@ -476,6 +476,8 @@
 ||mystats.nl^$third-party
 ||stealth.nl^$third-party
 ||svtrd.com^$third-party
+||r42tag.com^$third-party
+||synovite-scripts.com^$third-party
 ||traffic4u.nl^$third-party
 ! Estonian
 ||counter.ok.ee^$third-party


### PR DESCRIPTION
Along with svtrd.com, the same company has tracking scripts that uses 2 other domains. 

### List the website(s) you're having issues:
```
www.gamma.nl
www.postcodeloterij.nl
```
### What happens?

### List Subscriptions you're using:

ublock origin

### Your settings

- OS/version:  
- Browser/version: Firefox / 59.0.2 (64-bit)
- Adblock Extension/version: uBlock Origin 1.5.24

### Other details: 

